### PR TITLE
Fix Introduction-card tabindex typo

### DIFF
--- a/scripts/tag/Introduction-card.js
+++ b/scripts/tag/Introduction-card.js
@@ -28,7 +28,7 @@ function intCard(args) {
           </div>
         </div>
         <div class="right">
-          <a href="${urlFor(link)}" tableindex="-1" class="no-text-decoration">前往</a>
+          <a href="${urlFor(link)}" tabindex="-1" class="no-text-decoration">前往</a>
         </div>
       </div>
     `;


### PR DESCRIPTION
## Summary
- fix typo in Introduction-card tag: use `tabindex` attribute instead of `tableindex`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_683d274ba62483289c3930eec8b21f21