### PR TITLE
Add version helper test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Simple and Card UI Design theme for Hexo",
   "main": "package.json",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "keywords": [
     "hexo",
@@ -25,6 +25,9 @@
   "dependencies": {
     "hexo-renderer-stylus": "^3.0.0",
     "hexo-renderer-pug": "^3.0.0"
+  },
+  "devDependencies": {
+    "mocha": "^10.2.0"
   },
   "homepage": "https://blog.anheyu.com/",
   "author": "anzhiyu <me@anheyu.com>",

--- a/tests/get_version.test.js
+++ b/tests/get_version.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+
+// Mock hexo object to capture helper function
+const registered = {};
+
+global.hexo = {
+  extend: {
+    helper: {
+      register(name, fn) {
+        registered[name] = fn;
+      },
+    },
+  },
+};
+
+require('../scripts/helpers/get_version');
+
+const getVersionHelper = registered['get_version'];
+
+const pkg = require('../package.json');
+
+assert.strictEqual(
+  typeof getVersionHelper, 'function',
+  'get_version helper should be registered'
+);
+
+const version = getVersionHelper();
+assert.strictEqual(version, pkg.version, 'helper should return package.json version');
+


### PR DESCRIPTION
## Summary
- add mocha dev dependency and a simple test script
- implement test that checks the helper's version

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d2a914aac8328ae1bcd66212ff1fa