### PR TITLE
Fix console branding to use LuoPo name

### DIFF
--- a/layout/includes/anzhiyu/log-js.pug
+++ b/layout/includes/anzhiyu/log-js.pug
@@ -40,7 +40,7 @@ script.
 
     //- 定义一组ASCII艺术以及相关的提示文字
     const ascll = [
-      `欢迎使用安知鱼主题`, //- 欢迎语
+      `欢迎使用落魄主题`, //- 欢迎语
       `君子之所愿, 愿赴汤蹈火`, //- 标语
       `
         ██╗     ██╗   ██╗████████╗████████╗████████╗
@@ -53,7 +53,7 @@ script.
       "落魄1.0修改版", //- 版本说明
       dnum, //- 已经过了多少天
       "天", //- 单位，天
-      "©#{since} By 安知鱼 V#{version}", //- 网站版权信息，显示年份和版本号
+      "©#{since} By 落魄 V#{version}", //- 网站版权信息，显示年份和版本号
     ];
 
     //- 定义另一组ASCII艺术，用于搞笑提示
@@ -98,7 +98,7 @@ script.
     setTimeout(
       console.warn.bind(
         console,
-        "%c ⚡ Powered by 安知鱼 %c 你正在访问 #{author} 的博客.",
+        "%c ⚡ Powered by 落魄 %c 你正在访问 #{author} 的博客.",
         "color:white; background-color:#f0ad4e", //- 设置警告的颜色和背景色
         ""
       )


### PR DESCRIPTION
## Summary
- update the console messages to show LuoPo theme name instead of Anzhiyu

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d31ec07dc8328b0079457a51e4bae